### PR TITLE
protect file systems when running fragmented genomes in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ All parameters permitted for AUGUSTUS can be used as augustus_parameters. The fo
 | chunksize (int) | 2500000 | If `chunksize=n` with `n > 0` is set and `jobs > 1`, each AUGUSTUS instance is executed on sequence segments of the maximum size `n`. |
 | overlap (int) | 500000 | If `overlap=n` with `n > 1` is set and `jobs > 1`, each AUGUSTUS instance is executed on sequence segments of size `chunksize` and the segments overlap by `n`. |
 | partitionHints (bool) | False | If this option is set to True, a hints file is given and `jobs > 1`, then the hints file is split into appropriate pieces for the respective AUGUSTUS jobs. |
-| minSplitSize (int) | 0 | The input fasta file is spilt to at least `minSplitSize=n` base pairs. Set `n=0` to split the input in single sequence files. |
+| minSplitSize (int) | 1000000 | The input fasta file is spilt to at least `minSplitSize=n` base pairs. Set `n=0` to split the input in single sequence files. |
 | partitionLargeSeqeunces (bool) | False | Parallelize large sequences by automatically setting the AUGUSTUS parameters `predictionStart` and `predictionEnd` based on the given values for `chunksize` and `overlap`. |
 | maxSeqSize (int) | 3500000 | The maximum length of a sequence from which the sequence is started to be partitioned. To turn on the paritioning `partitionLargeSeqeunces=True` must be set|
 debugOutputDir (string) | None | If the directory is specified, all generated files, i.e. the split of the input file and intermediate results, as well as the generated AUGUSTUS command lines are stored there. This option works only for the parallelization, i. e. `jobs > 1` is set. |

--- a/pygustus/options/parameters.json
+++ b/pygustus/options/parameters.json
@@ -1523,7 +1523,7 @@
         "type": "int",
         "usage": "minSplitSize=n",
         "default_value": "1000000",
-        "description": "The input fasta file is spilt to at least n base pairs. Set this to 1000000 to split the input in single sequence files.",
+        "description": "The input fasta file is spilt to at least n base pairs. Set this to 0 to split the input in single sequence files.",
         "exclude_apps": [
             "augustus",
             "etraining"

--- a/pygustus/options/parameters.json
+++ b/pygustus/options/parameters.json
@@ -1522,8 +1522,8 @@
         "development": false,
         "type": "int",
         "usage": "minSplitSize=n",
-        "default_value": "0",
-        "description": "The input fasta file is spilt to at least n base pairs. Set this to 0 to split the input in single sequence files.",
+        "default_value": "1000000",
+        "description": "The input fasta file is spilt to at least n base pairs. Set this to 1000000 to split the input in single sequence files.",
         "exclude_apps": [
             "augustus",
             "etraining"


### PR DESCRIPTION
problem: if an assembly contains 2.5 mio contigs, 2.5 mio files will be created. This damages file systems. Fix by creating files of a minimal size of 1000000 bp.

@LarsGab be aware of this.