### PR TITLE
Fix writing permissions

### DIFF
--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -128,7 +128,7 @@ def get_path_to_binary(options, program):
 
 
 def get_config_item(name):
-    config = set_json_file()
+    config_file = set_json_file()
     with open(config_file, 'r') as file:
         config = json.load(file)
 

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -213,7 +213,7 @@ def set_json_file():
         homedir = os.path.expanduser('~')
         new_config =  homedir + '/.pygustus/config.json'
         if not os.path.isfile(new_config) and os.access(homedir, os.W_OK):
-            os.mkdir(homedir + '.pygustus')
+            os.mkdir(homedir + '/.pygustus')
             shutil.copyfile('config.json', new_config)
         else:
             print("ERROR: failed to copy config.json to " + homedir + "./pygustus!")

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -1,4 +1,4 @@
-\65;6003;1cimport subprocess
+import subprocess
 import os
 import os.path
 import re

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -1,4 +1,4 @@
-import subprocess
+\65;6003;1cimport subprocess
 import os
 import os.path
 import re
@@ -128,8 +128,7 @@ def get_path_to_binary(options, program):
 
 
 def get_config_item(name):
-    js_file = set_json_file()
-    config_file = resource_filename('pygustus', js_file)
+    config = set_json_file()
     with open(config_file, 'r') as file:
         config = json.load(file)
 
@@ -137,8 +136,7 @@ def get_config_item(name):
 
 
 def set_config_item(name, value):
-    js_file = set_json_file()
-    config_file = resource_filename('pygustus', js_file)
+    config_file = set_json_file()
     with open(config_file, 'r+') as file:
         config = json.load(file)
         config.update({name: value})
@@ -207,14 +205,15 @@ def set_tmp_config_path(options=None, **kwargs):
 
 def set_json_file():
     '''If config.json file is not in a writable location, copy it to user's home and use that file hence forward.'''
-    if os.access(sysconfig.get_paths()["purelib"] + '/pygustus/config.json', os.W_OK):
-        return sysconfig.get_paths()["purelib"] + '/pygustus/config.json'
+    standard_pkg_json = resource_filename('pygustus', js_file)
+    if os.access(standard_pkg_json, os.W_OK):
+        return standard_pkg_json
     else:
         homedir = os.path.expanduser('~')
         new_config =  homedir + '/.pygustus/config.json'
         if not os.path.exists(homedir + "/.pygustus") and os.access(homedir, os.W_OK):
              os.mkdir(homedir + '/.pygustus')
         if not os.path.isfile(new_config) and os.access(homedir, os.W_OK):
-            shutil.copyfile(sysconfig.get_paths()["purelib"] + '/pygustus/config.json', new_config)
+            shutil.copyfile(standard_pkg_json, new_config)
         return new_config
         

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -212,11 +212,9 @@ def set_json_file():
     else:
         homedir = os.path.expanduser('~')
         new_config =  homedir + '/.pygustus/config.json'
+        if not os.path.exists(homedir + "/.pygustus") and os.access(homedir, os.W_OK):
+             os.mkdir(homedir + '/.pygustus')
         if not os.path.isfile(new_config) and os.access(homedir, os.W_OK):
-            os.mkdir(homedir + '/.pygustus')
             shutil.copyfile(sysconfig.get_paths()["purelib"] + '/pygustus/config.json', new_config)
-        else:
-            print("ERROR: failed to copy config.json to " + homedir + "./pygustus!")
-            exit(1)
         return new_config
         

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -11,7 +11,7 @@ from pkg_resources import resource_filename
 import pygustus.fasta_methods as fm
 import pygustus.gff_methods as gff
 from concurrent.futures import ThreadPoolExecutor
-
+import sysconfig
 
 def execute_bin_parallel(cmd, aug_options, jobs, chunksize, overlap, partition_sequences, part_hints, minsize, max_seq_size, debug_dir):
     print(f'Execute AUGUSTUS with {jobs} jobs in parallel.')
@@ -207,14 +207,14 @@ def set_tmp_config_path(options=None, **kwargs):
 
 def set_json_file():
     '''If config.json file is not in a writable location, copy it to user's home and use that file hence forward.'''
-    if os.access('config.json', os.W_OK):
-        return 'config.json'
+    if os.access(sysconfig.get_paths()["purelib"] + '/pygustus/config.json', os.W_OK):
+        return sysconfig.get_paths()["purelib"] + '/pygustus/config.json'
     else:
         homedir = os.path.expanduser('~')
         new_config =  homedir + '/.pygustus/config.json'
         if not os.path.isfile(new_config) and os.access(homedir, os.W_OK):
             os.mkdir(homedir + '/.pygustus')
-            shutil.copyfile('config.json', new_config)
+            shutil.copyfile(sysconfig.get_paths()["purelib"] + '/pygustus/config.json', new_config)
         else:
             print("ERROR: failed to copy config.json to " + homedir + "./pygustus!")
             exit(1)

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -235,9 +235,9 @@ def set_json_file():
 
     # generate a random file name that does not exist, yet
     characters = string.ascii_letters + string.digits
-    new_config = pygustus_cfg_dir + "/json_" + ''.join(random.choice(characters) for i in range(10)).config
+    new_config = pygustus_cfg_dir + "/json_" + ''.join(random.choice(characters) for i in range(10)) + ".config"
     while os.path.isfile(new_config):
-        new_config = pygustus_cfg_dir + "/json_" + ''.join(random.choice(characters) for i in range(10)).config
+        new_config = pygustus_cfg_dir + "/json_" + ''.join(random.choice(characters) for i in range(10)) + ".config"
 
     # copy the file
     shutil.copyfile(standard_pkg_json, new_config)

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -205,7 +205,7 @@ def set_tmp_config_path(options=None, **kwargs):
 
 def set_json_file():
     '''If config.json file is not in a writable location, copy it to user's home and use that file hence forward.'''
-    standard_pkg_json = resource_filename('pygustus', js_file)
+    standard_pkg_json = resource_filename('pygustus', 'config.json')
     if os.access(standard_pkg_json, os.W_OK):
         return standard_pkg_json
     else:

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -226,8 +226,8 @@ def set_json_file():
         file_creation_time = os.path.getctime(file_path)
         # Calculate the age of the file in seconds
         file_age = current_time - file_creation_time
-        # If the file is older than 4 weeks, delete it
-        if file_age > 4 * 7 * 24 * 60 * 60:
+        # If the file is older than 2 weeks, delete it
+        if file_age > 2 * 7 * 24 * 60 * 60:
             os.remove(file_path)
 
     # find template json file

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -215,5 +215,8 @@ def set_json_file():
              os.mkdir(homedir + '/.pygustus')
         if not os.path.isfile(new_config) and os.access(homedir, os.W_OK):
             shutil.copyfile(standard_pkg_json, new_config)
+        if not os.access(new_config, os.W_OK):
+            print("ERROR: Cannot write in file " + new_config + "!")
+            exit(1)
         return new_config
         

--- a/pygustus/util.py
+++ b/pygustus/util.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import os.path
 import re
 import json
 import shutil
@@ -127,7 +128,8 @@ def get_path_to_binary(options, program):
 
 
 def get_config_item(name):
-    config_file = resource_filename('pygustus', 'config.json')
+    js_file = set_json_file()
+    config_file = resource_filename('pygustus', js_file)
     with open(config_file, 'r') as file:
         config = json.load(file)
 
@@ -135,7 +137,8 @@ def get_config_item(name):
 
 
 def set_config_item(name, value):
-    config_file = resource_filename('pygustus', 'config.json')
+    js_file = set_json_file()
+    config_file = resource_filename('pygustus', js_file)
     with open(config_file, 'r+') as file:
         config = json.load(file)
         config.update({name: value})
@@ -200,3 +203,20 @@ def set_tmp_config_path(options=None, **kwargs):
         tmp_config_path = options.get_value_or_none('AUGUSTUS_CONFIG_PATH')
     if tmp_config_path:
         os.environ['AUGUSTUS_CONFIG_PATH'] = tmp_config_path
+
+
+def set_json_file():
+    '''If config.json file is not in a writable location, copy it to user's home and use that file hence forward.'''
+    if os.access('config.json', os.W_OK):
+        return 'config.json'
+    else:
+        homedir = os.path.expanduser('~')
+        new_config =  homedir + '/.pygustus/config.json'
+        if not os.path.isfile(new_config) and os.access(homedir, os.W_OK):
+            os.mkdir(homedir + '.pygustus')
+            shutil.copyfile('config.json', new_config)
+        else:
+            print("ERROR: failed to copy config.json to " + homedir + "./pygustus!")
+            exit(1)
+        return new_config
+        


### PR DESCRIPTION
- every job has its own json.config file
- this avoids that if someone is running multiple jobs in different environments, wrong config files are used for the wrong jobs
- never modify sites-packages
- we delete json.config files in home that are older than 2 weeks automatically (because they might otherwise accumulate of time...)